### PR TITLE
feat: add dataset ingestion pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
   "uvicorn[standard]>=0.30.6",
   "jinja2>=3.1.4",
   "python-multipart>=0.0.9",
-  "httpx>=0.28.1"
+  "httpx>=0.28.1",
+  "datasets>=4.0.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ safety>=3.2.0
 jsonschema>=4.23.0
 flake8>=7.1.0
 pytest>=8.3.0
+datasets>=4.0.0

--- a/src/ia_skeleton/ingest/__init__.py
+++ b/src/ia_skeleton/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion utilities."""
+
+from .pipeline import load_dataset
+
+__all__ = ["load_dataset"]

--- a/src/ia_skeleton/ingest/pipeline.py
+++ b/src/ia_skeleton/ingest/pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Dataset loading pipeline."""
+
+from pathlib import Path
+import csv
+import json
+from typing import List, Dict
+from datasets import Dataset
+
+
+def load_dataset(path: str) -> Dataset:
+    """Load a dataset from a CSV or JSONL file.
+
+    Args:
+        path: Path to the dataset file.
+
+    Returns:
+        A :class:`datasets.Dataset` containing the data.
+
+    Raises:
+        FileNotFoundError: If the path does not exist.
+        ValueError: If the file extension is unsupported.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+
+    ext = file_path.suffix.lower()
+    records: List[Dict[str, object]]
+    if ext == ".csv":
+        with file_path.open(newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            records = list(reader)
+    elif ext == ".jsonl":
+        with file_path.open(encoding="utf-8") as f:
+            records = [json.loads(line) for line in f if line.strip()]
+    else:
+        raise ValueError(f"Unsupported dataset format: {ext}")
+
+    return Dataset.from_list(records)

--- a/src/ia_skeleton/services/train.py
+++ b/src/ia_skeleton/services/train.py
@@ -1,0 +1,14 @@
+"""Model training service."""
+
+from ia_skeleton.ingest import load_dataset
+
+
+def train_model(dataset_path: str) -> int:
+    """Train a model on the dataset located at ``dataset_path``.
+
+    This is a placeholder implementation that simply loads the dataset
+    and returns the number of records.
+    """
+    dataset = load_dataset(dataset_path)
+    # Placeholder for actual training logic
+    return len(dataset)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,38 @@
+import pytest
+from datasets import Dataset
+from ia_skeleton.ingest import load_dataset
+from ia_skeleton.services.train import train_model
+
+
+def test_load_dataset_csv(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    ds = load_dataset(str(csv_path))
+    assert isinstance(ds, Dataset)
+    assert ds.num_rows == 2
+    assert ds[0]["a"] == "1"
+
+
+def test_load_dataset_jsonl(tmp_path):
+    jsonl_path = tmp_path / "data.jsonl"
+    jsonl_path.write_text('{"a":1,"b":2}\n{"a":3,"b":4}\n', encoding="utf-8")
+    ds = load_dataset(str(jsonl_path))
+    assert isinstance(ds, Dataset)
+    assert ds.num_rows == 2
+    assert ds[1]["b"] == 4
+
+
+def test_train_model_uses_load_dataset(tmp_path, monkeypatch):
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("x\n1\n", encoding="utf-8")
+
+    called = {}
+
+    def fake_loader(path: str):
+        called["path"] = path
+        return Dataset.from_list([{ "x": 1 }])
+
+    monkeypatch.setattr("ia_skeleton.services.train.load_dataset", fake_loader)
+    result = train_model(str(data_path))
+    assert called["path"] == str(data_path)
+    assert result == 1


### PR DESCRIPTION
## Summary
- add `load_dataset` helper with CSV and JSONL support
- integrate dataset loader in training service
- cover ingestion module with unit tests

## Testing
- `pytest tests/test_ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_68b33614e0a08320915e460e76f876ad