### PR TITLE
docs: add training and inference details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # IA — Squelette Gate 0
 Squelette minimal pour lancer le plan par étapes : policies, CI, observabilité, golden sets, simulateur, SBOM, snapshots.
+
+## Modules IA
+- `intent_router` : détermine l'intention d'une requête utilisateur (import de fichier ou question libre).
+- `min_echo` : service d'écho minimal utilisé pour les tests de connectivité.
+
+## Procédure d'entraînement
+1. Préparer un corpus d'exemples d'intentions.
+2. Entraîner un modèle `scikit-learn` (ex. `LogisticRegression`) et l'enregistrer dans `artifacts/model.joblib`.
+3. Mettre à jour le service pour charger ce modèle au démarrage.
+
+## Procédure d'inférence
+1. Lancer le serveur :
+   ```bash
+   uvicorn ia_skeleton.services.app.webui:app
+   ```
+2. Envoyer une requête à l'endpoint `/chat` :
+   ```bash
+   curl -X POST "http://localhost:8000/chat" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "q=Bonjour"
+   ```
+   Réponse attendue :
+   ```json
+   {"intent": "chat", "echo": "Bonjour"}
+   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
   "uvicorn[standard]>=0.30.6",
   "jinja2>=3.1.4",
   "python-multipart>=0.0.9",
-  "httpx>=0.28.1"
+  "httpx>=0.28.1",
+  "pydantic>=2.0",
+  "scikit-learn>=1.4"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- describe AI modules, training workflow and inference example in README
- list `pydantic` and `scikit-learn` dependencies

## Testing
- `pytest -q`
- `flake8` *(fails: many style errors in tracked build files)*

------
https://chatgpt.com/codex/tasks/task_e_68b346d80f388320ad5bc1e189385a73